### PR TITLE
Build with PIC

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,7 @@ cmake ^
     -G "%CMAKE_GENERATOR%" ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_POSITION_INDEPENDENT_CODE=1 ^
     ..
 
 cmake --build . --config Release

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,7 @@ mkdir build && cd build
 cmake \
     -DCMAKE_PREFIX_PATH=$PREFIX \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=1 \
     ..
 make
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - glpk_win.diff    # [win]
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9           # [win and py27]
     - vc14          # [win and py>=35]


### PR DESCRIPTION
Rebuild LEMON's static libraries with Position-Independent Code (PIC) enabled. This is needed when linking static libraries into shared libraries where PIC is a requirement.